### PR TITLE
Added upsert: insert or update, to default store.

### DIFF
--- a/app/src/androidTest/java/com/navapp/data/DefaultStoreModelTest.java
+++ b/app/src/androidTest/java/com/navapp/data/DefaultStoreModelTest.java
@@ -99,4 +99,37 @@ public class DefaultStoreModelTest {
         DefaultStoreModel storedModel = dao.getDefaultByTable(DefaultStoreTable.RATE);
         assertThat(storedModel, nullValue(DefaultStoreModel.class));
     }
+
+    @Test
+    public void upsertAndRead_doesNotHaveRow_finishesSuccessfully() throws Exception {
+        final DefaultStoreModel INSERT_MODEL = new DefaultStoreModel(
+                DefaultStoreTable.RATE,
+                fakeModels.makeFakeRate().getId()
+        );
+
+        dao.upsert(INSERT_MODEL);
+
+        List<DefaultStoreModel> models = dao.getAll();
+        assertThat(models, hasSize(1));
+        assertThat(models.get(0), equalTo(INSERT_MODEL));
+    }
+
+    @Test
+    public void upsertAndRead_hasRow_finishesSuccessfully() throws Exception {
+        final DefaultStoreModel INSERT_MODEL = new DefaultStoreModel(
+                DefaultStoreTable.RATE,
+                fakeModels.makeFakeRate().getId()
+        );
+        dao.upsert(INSERT_MODEL);
+
+        final DefaultStoreModel UPDATE_MODEL = new DefaultStoreModel(
+                DefaultStoreTable.RATE,
+                fakeModels.makeFakeRate().getId()
+        );
+        dao.upsert(UPDATE_MODEL);
+
+        List<DefaultStoreModel> models = dao.getAll();
+        assertThat(models, hasSize(1));
+        assertThat(models.get(0), equalTo(UPDATE_MODEL));
+    }
 }

--- a/app/src/main/java/com/navapp/data/DefaultStoreDao.java
+++ b/app/src/main/java/com/navapp/data/DefaultStoreDao.java
@@ -5,7 +5,9 @@ import java.util.List;
 import androidx.room.Dao;
 import androidx.room.Delete;
 import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
+import androidx.room.Transaction;
 import androidx.room.Update;
 
 @Dao
@@ -17,8 +19,18 @@ public interface DefaultStoreDao {
 
     @Insert
     void insert(DefaultStoreModel store);
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    long tryInsert(DefaultStoreModel store);
     @Update
     void update(DefaultStoreModel store);
     @Delete
     void delete(DefaultStoreModel store);
+
+    @Transaction
+    default void upsert(DefaultStoreModel model) {
+        long id = tryInsert(model);
+        if (id == -1) {
+            update(model);
+        }
+    }
 }

--- a/app/src/main/java/com/navapp/data/DefaultStoreModel.java
+++ b/app/src/main/java/com/navapp/data/DefaultStoreModel.java
@@ -47,7 +47,7 @@ public class DefaultStoreModel {
     @Ignore
     public DefaultStoreModel(DefaultStoreTable table, long rowId) {
         this(table, null, null);
-        table.setInModel(this, rowId);
+        setRowId(rowId);
     }
 
     public DefaultStoreTable getTable() {
@@ -84,5 +84,12 @@ public class DefaultStoreModel {
     @Override
     public int hashCode() {
         return Objects.hash(table, rateId, endPointId);
+    }
+
+    public long getRowId() {
+        return table.getFromModel(this);
+    }
+    public void setRowId(long rowId) {
+        table.setInModel(this, rowId);
     }
 }


### PR DESCRIPTION
In databases, insert refers to adding a new row, and update refers to updating a row.
`upsert` makes that by itself, meaning that it will `insert` if the row is not in the database, and update otherwise.

Added to the defaults table for now. Maybe will add to others in the future.